### PR TITLE
missing line that is not updating pypi version

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -39,7 +39,9 @@ jobs:
     #                 build dist
     #----------------------------------------------
     - name: Build source and wheel archives
-      run: poetry build
+      run: |
+        poetry version $(git describe --tags --abbrev=0)
+        poetry build
 
     #----------------------------------------------
     #          publish package to PyPI     


### PR DESCRIPTION
Add this line so PyPI uses the right version number from the releases section rather than the hardcoded version in pyproject.toml.